### PR TITLE
Adding CentOS 7 Support

### DIFF
--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -123,8 +123,9 @@ action :start do
       service_name "dirsrv"
       supports :status => true
       if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
-        start_command "systemctl start dirsrv@#{new_resource.instance}"
-        status_command "systemctl status dirsrv@#{new_resource.instance}"
+        start_command "systemctl start dirsrv\\@#{new_resource.instance}"
+        restart_command "systemctl restart dirsrv\\@#{new_resource.instance}"
+        status_command "systemctl status dirsrv\\@#{new_resource.instance}"
       else
         start_command "service dirsrv start #{new_resource.instance}"
         status_command "service dirsrv status #{new_resource.instance}"
@@ -151,8 +152,8 @@ action :stop do
       service_name "dirsrv"
       supports :status => true
       if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
-        start_command "systemctl stop dirsrv@#{new_resource.instance}"
-        status_command "systemctl status dirsrv@#{new_resource.instance}"
+        stop_command "systemctl stop dirsrv\\@#{new_resource.instance}"
+        status_command "systemctl status dirsrv\\@#{new_resource.instance}"
       else
         stop_command "service dirsrv stop #{new_resource.instance}"
         status_command "service dirsrv status #{new_resource.instance}"
@@ -175,8 +176,8 @@ action :restart do
       service_name "dirsrv"
       supports :status => true, :restart => true
       if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
-        start_command "systemctl restart dirsrv@#{new_resource.instance}"
-        status_command "systemctl status dirsrv@#{new_resource.instance}"
+        restart_command "systemctl restart dirsrv\\@#{new_resource.instance}"
+        status_command "systemctl status dirsrv\\@#{new_resource.instance}"
       else
         restart_command "service dirsrv restart #{new_resource.instance}"
         status_command "service dirsrv status #{new_resource.instance}"

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -122,8 +122,13 @@ action :start do
     service "dirsrv-#{new_resource.instance}" do
       service_name "dirsrv"
       supports :status => true
-      start_command "service dirsrv start #{new_resource.instance}"
-      status_command "service dirsrv status #{new_resource.instance}"
+      if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
+        start_command "systemctl start dirsrv@#{new_resource.instance}"
+        status_command "systemctl status dirsrv@#{new_resource.instance}"
+      else
+        start_command "service dirsrv start #{new_resource.instance}"
+        status_command "service dirsrv status #{new_resource.instance}"
+      end
       action :start
     end
 
@@ -145,8 +150,13 @@ action :stop do
     service "dirsrv-#{new_resource.instance}" do
       service_name "dirsrv"
       supports :status => true
-      stop_command "service dirsrv stop #{new_resource.instance}"
-      status_command "service dirsrv status #{new_resource.instance}"
+      if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
+        start_command "systemctl stop dirsrv@#{new_resource.instance}"
+        status_command "systemctl status dirsrv@#{new_resource.instance}"
+      else
+        stop_command "service dirsrv stop #{new_resource.instance}"
+        status_command "service dirsrv status #{new_resource.instance}"
+      end
       action :stop
     end
 
@@ -164,8 +174,13 @@ action :restart do
     service "dirsrv-#{new_resource.instance}" do
       service_name "dirsrv"
       supports :status => true, :restart => true
-      restart_command "service dirsrv restart #{new_resource.instance}"
-      status_command "service dirsrv status #{new_resource.instance}"
+      if node[:platform_family] == 'rhel' && node[:platform_version].to_i >= 7
+        start_command "systemctl restart dirsrv@#{new_resource.instance}"
+        status_command "systemctl status dirsrv@#{new_resource.instance}"
+      else
+        restart_command "service dirsrv restart #{new_resource.instance}"
+        status_command "service dirsrv status #{new_resource.instance}"
+      end
       action :restart
     end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,8 +23,8 @@ include_recipe "ldap"
 if node[:dirsrv][:use_yum_epel] and platform_family?("rhel")
   yum_repository 'epel' do
     description 'Extra Packages for Enterprise Linux'
-    mirrorlist 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
-    gpgkey 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    mirrorlist "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{node[:platform_version].split(".").first}&arch=$basearch"
+    gpgkey "http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node[:platform_version].split(".").first}"
     action :create
   end
 end


### PR DESCRIPTION
Only had to tweak a couple of things:

1. When creating the EPEL repo, it's necessary to dynamically set the EPEL version number.
1. In CentOS 7, `systemd` is now used for service management, which means the command used to manage a service has changed; I've added a conditional to check `platform_family` and `platform_version` in order to use the appropriate command format.